### PR TITLE
Fix for 2 video players spawned.

### DIFF
--- a/kpl
+++ b/kpl
@@ -77,7 +77,7 @@ _launcher () {
 }
 
 _quality () {
-  RESOLUTION=$(streamlink twitch.tv/$MAIN | grep -i  audio_only | cut -c 19- | tr , '\n' | tac | cut -d ' ' -f 2)
+  RESOLUTION=$(streamlink twitch.tv/$MAIN --player=none | grep -i  audio_only | cut -c 19- | tr , '\n' | tac | cut -d ' ' -f 2)
   QUALITY=$(echo "$RESOLUTION" | _rofi -theme-str 'inputbar { children: [prompt];}' \
   -no-custom -p "Select stream quality")
   if [ -z "$QUALITY" ]; then


### PR DESCRIPTION
- If the user has a player set in streamlink config a video is displayed by the quality discovery streamlink. Overriding with player none for this discovery only usage of streamlink.