### PR TITLE
Don't default to best on watch now if streamlink has a quality order set

### DIFF
--- a/kpl
+++ b/kpl
@@ -134,6 +134,13 @@ else
   _filecheck
 fi
 
+# Checking if streamlink has default-stream set to handle quality questions
+if [ -z "$XDG_CONFIG_HOME" ]; then
+  SL_FILE=~/.config/streamlink/config
+else
+  SL_FILE=$XDG_CONFIG_HOME/streamlink/config
+fi
+
 # Grab configuration file
 source $MAIN_PATH/config
 
@@ -158,7 +165,11 @@ fi
 x=1
 while [[ $x -le 1 ]]; do
   y=1
-  QUALITY=best
+  if [[ -f "$SL_FILE" ]] && [[ $(grep -c ^default-stream $SL_FILE) -eq 1 ]]; then
+    QUALITY=""
+  else
+    QUALITY=best
+  fi
   STREAMS=$(jq -r '.streams[].channel.display_name' $MAIN_PATH/followdata.json)
 
   # Listing said streams with rofi


### PR DESCRIPTION
Streamlink has a nice config option (not set by default) to list preferred stream qualities in order (default-stream), since the user has made the decision to set that, lets respect that decision.

- If streamlink config item exists, run streamlink allowing it to decide quality if Watch now is picked, i.e. QUALITY="".
- If streamlink item doesn't exist Watch now still defaults to best
- User can still pick quality in Choose quality.