### PR TITLE
Make streamlink arguments configurable

### DIFF
--- a/kpl
+++ b/kpl
@@ -46,6 +46,9 @@ VIEW=legacy
 # Either we discover font and font size or you can set a font and size below.
 # This is the same format as rofi uses.
 FONT="mono 12"
+
+# Extra arguments passed to streamlink
+STREAMLINK_ARGS=""
 EOF
 }
 
@@ -72,7 +75,7 @@ _launcher () {
     if [[ "$MULTIPLE" != "true" ]]; then
       killall -9 "$PLAYER" "$CHAT" &
     fi
-    streamlink --hls-live-edge=1 --player="$PLAYER" twitch.tv/$MAIN $QUALITY &
+    streamlink $STREAMLINK_ARGS --player="$PLAYER" twitch.tv/$MAIN $QUALITY &
     echo "launching $STREAM"
     sleep 1
     if [[ "$CHAT" = "chatterino" ]]; then


### PR DESCRIPTION
The launcher passes `--hls-live-edge=1` to streamlink when launching a stream, however for me this causes the stream to constantly lag and stutter. When launching streamlink through [Streamlink Twitch GUI](https://github.com/streamlink/streamlink-twitch-gui), it passes a different set of arguments and there is no lag.

Thus this PR adds `STREAMLINK_ARGS` as a configuration option to enable configuring the arguments that are passed to streamlink. Also, even though previously the default was `--hls-live-edge=1` I would not set it as the default for `STREAMLINK_ARGS` to maximize compatibility and hopefully prevent others from having the same issue I had.